### PR TITLE
Replace isatty with atty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /target
 /Cargo.lock
+.idea
+.arrow_history

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ version = "0.1.0"
 
 [dependencies]
 shlex = "1.1.0"
-isatty = "0.1.9"
+atty = "0.2"
 rustyline = "11.0.0"
 arrow-cast = { version = "51", features = ["prettyprint"] }
 arrow-flight = { version = "51", features = ["flight-sql-experimental"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,8 +4,7 @@ mod session;
 use std::time::Duration;
 
 use arrow::error::ArrowError;
-
-use isatty::stdin_isatty;
+use atty::Stream;
 
 use clap::Parser;
 use tonic::transport::{ClientTlsConfig, Endpoint};
@@ -53,7 +52,7 @@ pub async fn main() -> Result<(), ArrowError> {
     // Authenticate
     let url = format!("{protocol}://{}:{}", args.host, args.port);
     let endpoint = endpoint(&args, url)?;
-    let is_repl = stdin_isatty();
+    let is_repl = atty::is(Stream::Stdin);
     let mut session =
         session::Session::try_new(endpoint, &args.user, &args.password, is_repl).await?;
 


### PR DESCRIPTION
`isatty ` is deprecated, the author suggests to use `atty`. And `isatty::stdin_isatty` method not implemented on windows. 
Tested on windows.
![image](https://github.com/sundy-li/arrow_cli/assets/17514693/7279f2fb-275f-4323-b1d3-1b86020ac044)
